### PR TITLE
PreLec2: fix a couple typos

### DIFF
--- a/Archive/2017/ConceptChecks/2-PreLec-Check.ltx
+++ b/Archive/2017/ConceptChecks/2-PreLec-Check.ltx
@@ -43,7 +43,7 @@
   \end{array}$$
   Solve the following questions.
   \begin{enumerate}
-  \item If $x$ in the first problem satistfies $f(x)\in S$ show how to quickly
+  \item If $x$ in the first problem satisfies $f(x)\in S$ show how to quickly
     compute $(a,b)$ for the second problem with $a+b=|x|$ and
     $f(a-b)\in S$.
   \item If $a,b$ in the second problem

--- a/Archive/2018/ConceptChecks/2-PreLec-Check.ltx
+++ b/Archive/2018/ConceptChecks/2-PreLec-Check.ltx
@@ -44,7 +44,7 @@
   \end{array}$$
   Solve the following questions.
   \begin{enumerate}
-  \item If $x$ in the first problem satistfies $f(x)\in S$ show how to quickly
+  \item If $x$ in the first problem satisfies $f(x)\in S$ show how to quickly
     compute $(a,b)$ for the second problem with $a+b=|x|$ and
     $f(a-b)\in S$.
   \item If $a,b$ in the second problem

--- a/ConceptChecks/2-PreLec-Check.ltx
+++ b/ConceptChecks/2-PreLec-Check.ltx
@@ -44,7 +44,7 @@
   \end{array}$$
   Solve the following questions.
   \begin{enumerate}
-  \item If $x$ in the first problem satistfies $f(x)\in S$ show how to quickly
+  \item If $x$ in the first problem satisfies $f(x)\in S$ show how to quickly
     compute $(a,b)$ for the second problem with $a+b=|x|$ and
     $f(a-b)\in S$.
   \item If $a,b$ in the second problem


### PR DESCRIPTION
just a couple typos in the PR.

Also, there is 1 more misalignment, but I'm not sure where would be the best place to fix (grad VS gradient).
HW1, ```skeleton.py``` has
```
def batch_grad_descent(X, y, alpha=0.1, num_iter=1000, check_gradient=False):
...
```

but comment below says
```
###Q2.4b: Implement backtracking line search in batch_gradient_descent
```

And ```hw1.lyx``` has
```\begin_layout Enumerate
Complete 
\family typewriter
batch_gradient_descent
\family default
.
```